### PR TITLE
Add Range support to media fields

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Add widget that supports streaming partial ranges of video content
+  from video and audio fields. This package now supports video seeking
+  in Chrome and iOS video display with content-range request support. 
+  [davidjb]
 - Configure CSS to apply prefix to local resources utilised for
   MediaElement.js. Previously, images used in CSS did not load
   when running outside of debug mode.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(name='wildcard.media',
           'plone.transformchain',
           'plone.app.dexterity',
           'plone.autoform',
-          'plone.app.textfield'
+          'plone.app.textfield',
+          'plone.app.blob'
       ],
       extras_require={
           'test': [

--- a/wildcard/media/behavior.py
+++ b/wildcard/media/behavior.py
@@ -9,6 +9,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.namedfile import field as namedfile
 from wildcard.media import _
 from wildcard.media.async import queueJob
+from wildcard.media.widget import StreamNamedFileFieldWidget
 from zope.interface import Invalid, invariant
 import json
 from plone.autoform import directives as form
@@ -37,6 +38,7 @@ class IVideo(model.Schema):
     )
 
     # main file will always be converted to mp4
+    form.widget('video_file', StreamNamedFileFieldWidget)
     video_file = namedfile.NamedBlobFile(
         title=_(u"Video File"),
         description=u"",
@@ -45,11 +47,13 @@ class IVideo(model.Schema):
     )
 
     form.omitted(IEditForm, 'video_file_ogv')
+    form.widget('video_file_ogv', StreamNamedFileFieldWidget)
     video_file_ogv = namedfile.NamedBlobFile(
         required=False,
     )
 
     form.omitted(IEditForm, 'video_file_webm')
+    form.widget('video_file_webm', StreamNamedFileFieldWidget)
     video_file_webm = namedfile.NamedBlobFile(
         required=False,
     )
@@ -103,6 +107,7 @@ alsoProvides(IVideo, IFormFieldProvider)
 class IAudio(model.Schema):
 
     # main file will always be converted to mp4
+    form.widget('audio_file', StreamNamedFileFieldWidget)
     audio_file = namedfile.NamedBlobFile(
         title=_(u"Audio File"),
         description=u"",

--- a/wildcard/media/browser.py
+++ b/wildcard/media/browser.py
@@ -26,9 +26,8 @@ class MediaView(BrowserView):
 class AudioView(MediaView):
     def __call__(self):
         self.setUp()
-        self.audio_url = '%sIAudio.audio_file/@@download/%s' % (
+        self.audio_url = '%sIAudio.audio_file/@@stream' % (
             self.base_wurl,
-            self.context.audio_file.filename
         )
         return self.index()
 
@@ -46,17 +45,14 @@ class VideoMacroView(MediaView):
             format = getFormat(type_)
             if format:
                 types.append((format.type_,
-                              'video_file_%s' % format.extension))
+                              'video_file_' + format.extension))
         self.videos = []
         for (_type, fieldname) in types:
             file = getattr(context, fieldname, None)
             if file:
                 self.videos.append({
                     'type': _type,
-                    'url': '%s%s/@@download/%s' % (
-                        self.base_furl,
-                        fieldname,
-                        file.filename)
+                    'url': self.base_furl + fieldname + '/@@stream'
                 })
         if self.videos:
             self.mp4_url = self.videos[0]['url']

--- a/wildcard/media/configure.zcml
+++ b/wildcard/media/configure.zcml
@@ -63,6 +63,13 @@
       />
 
   <browser:page
+    name="stream"
+    for=".widget.IStreamNamedFileWidget"
+    class=".widget.MediaStream"
+    permission="zope2.View"
+    />
+
+  <browser:page
     name="wildcard_video_macro"
     for=".interfaces.IVideoEnabled"
     class=".browser.VideoMacroView"

--- a/wildcard/media/tests/test_audio.py
+++ b/wildcard/media/tests/test_audio.py
@@ -107,6 +107,9 @@ class AudioFunctionalTest(unittest.TestCase):
         self.assertTrue('My audio' in self.browser.contents)
         self.assertTrue('This is my audio' in self.browser.contents)
         self.assertTrue('<audio' in self.browser.contents)
+        self.assertIn(
+            '++widget++form.widgets.IAudio.audio_file/@@stream',
+            self.browser.contents)
 
 
 def test_suite():

--- a/wildcard/media/widget.py
+++ b/wildcard/media/widget.py
@@ -1,0 +1,58 @@
+from zope.interface import implements, implementer, implementsOnly
+from zope.component import adapter, getMultiAdapter
+from z3c.form.interfaces import IFieldWidget, IFormLayer, IDataManager
+from z3c.form.widget import FieldWidget
+from plone.formwidget.namedfile.interfaces import INamedFileWidget
+from plone.formwidget.namedfile.widget import NamedFileWidget, Download
+from plone.namedfile.interfaces import INamedFileField
+from plone.namedfile.utils import get_contenttype
+from plone.app.blob.field import BlobWrapper
+
+from Acquisition import aq_inner
+from zope.publisher.interfaces import NotFound
+
+
+class IStreamNamedFileWidget(INamedFileWidget):
+    pass
+
+
+class StreamNamedFileWidget(NamedFileWidget):
+    implementsOnly(IStreamNamedFileWidget)
+
+
+@implementer(IFieldWidget)
+@adapter(INamedFileField, IFormLayer)
+def StreamNamedFileFieldWidget(field, request):
+    return FieldWidget(field, StreamNamedFileWidget(request))
+
+
+
+class MediaStream(Download):
+    """ Browser view for handling media streaming requests.
+    """
+
+    def __call__(self):
+        """ Partially reproduced from plone.formwidget.namedfile.widget.Download.
+
+        Leverages the existing BlobWrapper functionality to stream the media blobs
+        to the client, allowing ranges and partial content.
+        """
+        if self.context.ignoreContext:
+            raise NotFound("Cannot get the data file from a widget with no context")
+
+        if self.context.form is not None:
+            content = aq_inner(self.context.form.getContent())
+        else:
+            content = aq_inner(self.context.context)
+        field = aq_inner(self.context.field)
+
+        dm = getMultiAdapter((content, field,), IDataManager)
+        file_ = dm.get()
+        if file_ is None:
+            raise NotFound(self, self.request)
+
+        content_type = get_contenttype(file_)
+        blob_wrapper = BlobWrapper(content_type)
+        blob_wrapper.setBlob(file_)
+
+        return blob_wrapper.index_html(self.request)


### PR DESCRIPTION
Creates a custom field widget which has a "stream" view associated with it.  This view correctly responds to partial content requests for media (via Plone's existing blob iterator), meaning seeking is now possible.  Previously, a browser would need to download the entire video before this would be possible (or in Chrome's case, refuse to see at all).

Adding support for content ranges also ensures that iOS can view videos (see documentation requiring [byte-range support](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariWebContent/CreatingVideoforSafarioniPhone/CreatingVideoforSafarioniPhone.html#//apple_ref/doc/uid/TP40006514-SW6))
