### PR TITLE
Add control panel options to set outfile and infile parameters during th...

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -38,6 +38,19 @@ On Ubuntu, you should be able to install with::
 
     sudo apt-get install libav-tools
 
+Conversion
+----------
+
+Some versions of `avconv` may require extra arguments during the conversion
+process so that the conversion process succeeds and produces output files in
+a valid format. Extra `infile` and `outfile` options can be configured in the
+control panel.
+
+    avconv [infile options] -i infile [outfile options] outfile
+
+The latest version of avconv on Ubuntu may require `-strict experimental` as an
+outfile option.
+
 
 YouTube API Support
 -------------------

--- a/wildcard/media/convert.py
+++ b/wildcard/media/convert.py
@@ -1,9 +1,14 @@
+try:
+    from zope.app.component.hooks import getSite
+except ImportError:
+    from zope.component.hooks import getSite
 import subprocess
 import os
 from logging import getLogger
 from plone.app.blob.utils import openBlob
 from tempfile import mkdtemp
 from shutil import copyfile, rmtree
+import shlex
 from wildcard.media.config import getFormat
 from plone.namedfile import NamedBlobFile, NamedBlobImage
 from wildcard.media.settings import GlobalSettings
@@ -78,7 +83,13 @@ class AVConvProcess(BaseSubProcess):
         bin_name = 'avconv'
 
     def convert(self, filepath, outputfilepath):
-        cmd = [self.binary, '-i', filepath, outputfilepath]
+        portal = getSite()
+        settings = GlobalSettings(portal)
+
+        infile_options = shlex.split(settings.convert_infile_options or '')
+        outfile_options = shlex.split(settings.convert_outfile_options or '')
+        cmd = [self.binary] + infile_options + ['-i', filepath] + outfile_options + [outputfilepath]
+
         self._run_command(cmd)
 
     def grab_frame(self, filepath, outputfilepath, instant='00:00:5'):

--- a/wildcard/media/interfaces.py
+++ b/wildcard/media/interfaces.py
@@ -49,6 +49,28 @@ class IGlobalMediaSettings(Interface):
                       "The quota name assigned is `wildcard.media`."),
         default=3)
 
+    convert_infile_options = schema.TextLine(
+        title=_("Convert Infile Options"),
+        description=_(
+            'convert_infile_options_help',
+            default=u"Pass optional infile parameters to aconv during the "
+                    u"conversion process.\n"
+        ),
+        default=u'',
+        required=False,
+    )
+
+    convert_outfile_options = schema.TextLine(
+        title=_("Convert Outfile Options"),
+        description=_(
+            'convert_outfile_options_help',
+            default=u"Pass optional outfile parameters to aconv during the "
+                    u"conversion process."
+        ),
+        default=u'',
+        required=False,
+    )
+
 
 class IUtils(Interface):
     def valid_type(self):


### PR DESCRIPTION
This adds two options to the control panel for setting both infile and outfile options. These are passed to the avconv process when a file is converted.

    avconv [infile options] -i infile [outfile options] outfile