### PR TITLE
Add workaround for broken dexterity/fileUpload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ parts/
 dist/
 var/
 .eggs
+include
+lib

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,9 @@ Changelog
 - add Google and universal analytics MediaElement.js plugins
   [ivanteoh]
 
+- fix fileUpload fails when Wildcard.Video is registered as the video type
+  [displacedaussie]
+
 2.0.2 (2015-11-25)
 ------------------
 

--- a/wildcard/media/behavior.py
+++ b/wildcard/media/behavior.py
@@ -231,6 +231,14 @@ class Video(BaseAdapter):
     def __init__(self, context):
         self.context = context
 
+    # For when a fileUpload sends us a file
+    def _get_file(self):
+        return self.context.video_file
+
+    def _set_file(self, value):
+        self.video_file = value
+    file = property(_get_file, _set_file)
+
     def _get_video_file(self):
         return self.context.video_file
 

--- a/wildcard/media/tests/test_video.py
+++ b/wildcard/media/tests/test_video.py
@@ -124,6 +124,15 @@ class VideoIntegrationTest(unittest.TestCase):
         self.assertEquals(info.fieldname, 'video_file')
         self.assertTrue(IPrimaryField.providedBy(info.field))
 
+    def test_file_field(self):
+        '''Although video_file is the Primary field, DX might attempt to set
+        the file on the file attribute'''
+        video = self.create('videof')
+        blob = getVideoBlob('mp4')
+        video.file = blob
+        self.assertEqual(video.video_file.size, blob.size)
+        self.assertEqual(video.video_file.filename, blob.filename)
+
 
 class VideoFunctionalTest(unittest.TestCase):
 


### PR DESCRIPTION
This PR provides a workaround for this issue: https://github.com/collective/wildcard.media/issues/32

If wildcard.video is set as the registered type in the content type registry for video files, a fileUpload via folder_contents currently fails because `video_file` is the primary field instead of `file`. This workaround sets the `video_file` via `file`.