### PR TITLE
Add support for separate avconv parameters per output format

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,15 +52,25 @@ Must have plone.app.jquery >= 1.8.3
 Conversion
 ----------
 
-Some versions of ``avconv`` may require extra arguments during the conversion
-process so that the conversion process succeeds and produces output files in
-a valid format. Extra ``infile`` and ``outfile`` options can be configured in
-the control panel::
+Force Conversion
+~~~~~~~~~~~~~~~~
 
-    avconv [infile options] -i infile [outfile options] outfile
+Uploaded videos can be forced through the video conversion process by enabling
+the ``Force video conversion`` option. This option is useful if you would like
+to transcode all videos down to a certain resolution; or if you want to enforce
+a certain quality setting or video profile across all uploads.
+
+Conversion Parameters
+~~~~~~~~~~~~~~~~~~~~~
+
+You may like to pass certain parameters to ``avconv`` to customise the video
+transcoding process. Extra ``infile`` and ``outfile`` options can be configured
+in the control panel per video format:
+
+    avconv [infile options] -i infile [outfile options] outfile.{format}
 
 The latest version of ``avconv`` on Ubuntu may require 
-``-strict experimental`` as an ``outfile`` option.
+``-strict experimental`` as an ``outfile`` option for the mp4 format.
 
 
 YouTube API Support

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -16,6 +16,9 @@ Changelog
 - fix fileUpload fails when Wildcard.Video is registered as the video type
   [displacedaussie]
 
+- add support for separate avconv parameters per output format
+  [displacedaussie]
+
 2.0.2 (2015-11-25)
 ------------------
 

--- a/wildcard/media/browser/views.py
+++ b/wildcard/media/browser/views.py
@@ -107,6 +107,8 @@ GlobalSettingsFormView = wrap_form(GlobalSettingsForm)
 
 class ConvertVideo(BrowserView):
     def __call__(self):
+        # Mark the video as not converted
+        self.context.video_converted = False
         video_edited(self.context, None)
         self.request.response.redirect(self.context.absolute_url())
 

--- a/wildcard/media/browser/views.py
+++ b/wildcard/media/browser/views.py
@@ -17,6 +17,7 @@ from wildcard.media.subscribers import video_edited
 from z3c.form import button
 from z3c.form import field
 from z3c.form import form
+from z3c.form import group
 from zope.component.hooks import getSite
 from zope.interface import alsoProvides
 
@@ -51,7 +52,6 @@ class AudioView(MediaView):
         self.ct = self.context.audio_file.contentType
         return self.index()
 
-
 class VideoView(BrowserView):
 
     def get_embed_url(self):
@@ -83,9 +83,21 @@ class VideoView(BrowserView):
         url = "%s/@@edit" % self.context.absolute_url()
         return addTokenToUrl(url)
 
+class DefaultGroup(group.Group):
+    label = u"Default"
+    fields = field.Fields(IGlobalMediaSettings).select(
+        "additional_video_formats", "async_quota_size",
+        "default_video_width", "default_video_height")
 
-class GlobalSettingsForm(form.EditForm):
-    fields = field.Fields(IGlobalMediaSettings)
+class ConversionSettingsGroup(group.Group):
+    label = u"Conversion settings"
+    fields = field.Fields(IGlobalMediaSettings).select(
+        "force", "avconv_in_mp4", "avconv_out_mp4",
+        "avconv_in_webm", "avconv_out_webm",
+        "avconv_in_ogg", "avconv_out_ogg")
+
+class GlobalSettingsForm(group.GroupForm, form.EditForm):
+    groups = (DefaultGroup, ConversionSettingsGroup)
 
     label = _(u"Media Settings")
     description = _(u'description_media_global_settings_form',

--- a/wildcard/media/interfaces.py
+++ b/wildcard/media/interfaces.py
@@ -49,27 +49,84 @@ class IGlobalMediaSettings(Interface):
                       "The quota name assigned is `wildcard.media`."),
         default=3)
 
-    convert_infile_options = schema.TextLine(
-        title=_("Convert Infile Options"),
+    force = schema.Bool(
+        title=_("Force video conversion"),
         description=_(
-            'convert_infile_options_help',
+            "always_convert_help",
+            default=u"Force the video through the full conversion "
+                    u"process, even if it is already in the final video format."
+                    u" This may be useful if you always want to transcode to a "
+                    u"given video size."
+        ),
+        default=False,
+    )
+
+    avconv_in_mp4 = schema.TextLine(
+        title=_("MP4: infile parameters"),
+        description=_(
+            'avconv_in_mp4_help',
             default=u"Pass optional infile parameters to aconv during the "
-                    u"conversion process.\n"
+                    u"MP4 conversion process."
         ),
         default=u'',
         required=False,
     )
 
-    convert_outfile_options = schema.TextLine(
-        title=_("Convert Outfile Options"),
+    avconv_out_mp4 = schema.TextLine(
+        title=_("MP4: outfile parameters"),
         description=_(
-            'convert_outfile_options_help',
+            'avconv_out_mp4_help',
             default=u"Pass optional outfile parameters to aconv during the "
-                    u"conversion process."
+                    u"MP4 conversion process."
         ),
         default=u'',
         required=False,
     )
+
+    avconv_in_webm = schema.TextLine(
+        title=_("WebM: infile parameters"),
+        description=_(
+            'avconv_in_webm_help',
+            default=u"Pass optional infile parameters to aconv during the "
+                    u"WebM conversion process."
+        ),
+        default=u'',
+        required=False,
+    )
+
+    avconv_out_webm = schema.TextLine(
+        title=_("WebM: outfile parameters"),
+        description=_(
+            'avconv_out_webm_help',
+            default=u"Pass optional outfile parameters to aconv during the "
+                    u"WebM conversion process."
+        ),
+        default=u'',
+        required=False,
+    )
+
+    avconv_in_ogg = schema.TextLine(
+        title=_("OGG: infile parameters"),
+        description=_(
+            'avconv_in_ogg_help',
+            default=u"Pass optional infile parameters to aconv during the "
+                    u"OGG conversion process."
+        ),
+        default=u'',
+        required=False,
+    )
+
+    avconv_out_ogg = schema.TextLine(
+        title=_("OGG: outfile parameters"),
+        description=_(
+            'avconv_out_ogg_help',
+            default=u"Pass optional outfile parameters to aconv during the "
+                    u"OGG conversion process."
+        ),
+        default=u'',
+        required=False,
+    )
+
 
     default_video_width = schema.Int(
         title=_(u'Default video width'),

--- a/wildcard/media/profiles.zcml
+++ b/wildcard/media/profiles.zcml
@@ -80,5 +80,13 @@
       sortkey="1"
       profile="wildcard.media:default"
       />
+   <genericsetup:upgradeStep
+      title="Upgrade to version 2.0.3"
+      source="2001"
+      destination="2003"
+      handler="wildcard.media.upgrades.upgrade_to_2003"
+      sortkey="1"
+      profile="wildcard.media:default"
+      />
 
 </configure>

--- a/wildcard/media/profiles/default/metadata.xml
+++ b/wildcard/media/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2001</version>
+  <version>2003</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
   </dependencies>

--- a/wildcard/media/upgrades.py
+++ b/wildcard/media/upgrades.py
@@ -1,5 +1,6 @@
 from Products.CMFPlone.utils import getToolByName
 from Products.CMFPlone.utils import getFSVersionTuple
+from wildcard.media.settings import GlobalSettings
 
 
 PROFILE_ID = 'profile-wildcard.media:default'
@@ -29,3 +30,20 @@ def upgrade_registry(context, logger=None):
 def upgrade_to_2(context):
     upgrade_registry(context)
     upgrade_resources(context)
+
+
+def upgrade_to_2003(context):
+    portal = getToolByName(context, 'portal_url').getPortalObject()
+    settings = GlobalSettings(portal)
+    # Apply old in/outfile options to each new format specific option
+    old_outfileopt = settings.convert_outfile_options
+    old_infileopt = settings.convert_infile_options
+
+    if old_outfileopt:
+        settings.avconv_out_mp4 = old_outfileopt
+        settings.avconv_out_ogg = old_outfileopt
+        settings.avconv_out_webm = old_outfileopt
+    if old_infileopt:
+        settings.avconv_in_mp4 = old_infileopt
+        settings.avconv_in_ogg = old_infileopt
+        settings.avconv_in_webm = old_infileopt


### PR DESCRIPTION
This pull request resolves https://github.com/collective/wildcard.media/issues/16

It provides:

 * Options for separate input/outfile parameters per output type
 * The ability to force conversion of uploaded videos

With `force` set to True, this ensures that any uploaded videos will be converted with suitable conversion parameters (for example the baseline MP4 profile, or downscaled to a lower resolution) if required.

Without these options it's not possible to customise the output/conversion process for each file type or to guarantee that a video ends up in the desired format.