### PR TITLE
Youtube iframe

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.0.3 (Unreleased)
+------------------
+
+- For youtube videos, use the iframe instead simple html5 video tag.
+  [cekk]
+
+
 2.0.2 (2015-11-25)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name='wildcard.media',
       extras_require={
           'test': [
               'plone.app.testing',
+              'unittest2'
           ],
           'youtube': [
               'requests',

--- a/wildcard/media/browser/configure.zcml
+++ b/wildcard/media/browser/configure.zcml
@@ -27,6 +27,7 @@
     for="..interfaces.IVideoEnabled"
     template="templates/video_view.pt"
     permission="zope2.View"
+    class=".views.VideoView"
     layer="..interfaces.ILayer"
   />
   <browser:page
@@ -94,5 +95,5 @@
     class=".forms.VideoEditForm"
     permission="cmf.ModifyPortalContent"
     />
-   
+
 </configure>

--- a/wildcard/media/browser/templates/video_macro.pt
+++ b/wildcard/media/browser/templates/video_macro.pt
@@ -7,7 +7,7 @@
                  height height|video/height|settings/default_video_height|string:720;
                  width width|video/width|settings/default_video_width|string:400;
                  upload_to_youtube video/upload_video_to_youtube|nothing;
-                 youtube_url video/youtube_url|nothing">
+                 youtube_url view/get_embed_url|nothing">
 <tal:has_video tal:condition="python: util.mp4_url and not upload_to_youtube and not youtube_url">
     <video width="320" height="240" poster="poster.jpg" controls="controls" preload="none" class="active pat-media"
           tal:attributes="poster util/image_url;
@@ -40,12 +40,19 @@
     </video>
 </tal:has_video>
 <tal:yt tal:condition="youtube_url">
-    <video width="640" height="360" id="player1" preload="none" class="active pat-media"
+  <iframe
+    tal:attributes="width width;
+                    height height;
+                    src youtube_url"
+    frameborder="0"
+    allowfullscreen>
+  </iframe>
+    <!-- <video width="640" height="360" id="player1" preload="none" class="active pat-media"
            tal:attributes="width width;
                            height height;">
         <source type="video/youtube" src="http://www.youtube.com/watch?v=nOEw9iiopwI"
                 tal:attributes="src video/youtube_url" />
-    </video>
+    </video> -->
 </tal:yt>
 </div>
 

--- a/wildcard/media/browser/views.py
+++ b/wildcard/media/browser/views.py
@@ -1,4 +1,5 @@
 import urllib
+import re
 
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as pmf
@@ -48,6 +49,27 @@ class AudioView(MediaView):
         )
         self.ct = self.context.audio_file.contentType
         return self.index()
+
+
+class VideoView(BrowserView):
+
+    def get_embed_url(self):
+        """
+        Try to guess video id from a various case of possible youtube urls and
+        returns the correct url for embed.
+        For example:
+        - 'https://youtu.be/VIDEO_ID'
+        - 'https://www.youtube.com/watch?v=VIDEO_ID'
+        - 'https://www.youtube.com/embed/2Lb2BiUC898'
+        """
+        if not getattr(self.context, 'youtube_url', None):
+            return ""
+        pattern = r"((?<=(v|V)/)|(?<=be/)|(?<=(\?|\&)v=)|(?<=embed/))([\w-]+)"
+        match = re.search(pattern, self.context.youtube_url)
+        if not match:
+            return ""
+        video_id = match.group()
+        return "https://www.youtube.com/embed/" + video_id
 
 
 class GlobalSettingsForm(form.EditForm):

--- a/wildcard/media/subscribers.py
+++ b/wildcard/media/subscribers.py
@@ -7,7 +7,7 @@ from wildcard.media.async import (
 
 
 def video_added(video, event):
-    if video.video_file:
+    if getattr(video, 'video_file', None):
         if getattr(video, 'upload_video_to_youtube', False):
             uploadToYouTube(video)
         else:

--- a/wildcard/media/tests/test_video.py
+++ b/wildcard/media/tests/test_video.py
@@ -170,5 +170,46 @@ class VideoFunctionalTest(unittest.TestCase):
             self.browser.contents)
 
 
+class YoutubeVideoIntegrationTest(unittest.TestCase):
+
+    layer = MEDIA_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        self.request['ACTUAL_URL'] = self.portal.absolute_url()
+        self.video_id = "2Lb2BiUC898"
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+    def getFti(self):
+        return queryUtility(IDexterityFTI, name='WildcardVideo')
+
+    def create(self, id, video_url):
+        self.portal.invokeFactory('WildcardVideo', id,
+                                  youtube_url=video_url)
+        return self.portal[id]
+
+    def test_yt_url_generation_short(self):
+        self.create('video1', 'https://youtu.be/' + self.video_id)
+        video = self.portal['video1']
+        view = video.restrictedTraverse('@@wildcard_video_view')
+        embed_url = 'https://www.youtube.com/embed/' + self.video_id
+        self.assertEqual(view.get_embed_url(), embed_url)
+
+    def test_yt_url_generation_classic(self):
+        self.create('video2', 'https://www.youtube.com/watch?v=2Lb2BiUC898')
+        video = self.portal['video2']
+        view = video.restrictedTraverse('@@wildcard_video_view')
+        embed_url = 'https://www.youtube.com/embed/' + self.video_id
+        self.assertEqual(view.get_embed_url(), embed_url)
+
+    def test_yt_url_generation_embed(self):
+        self.create('video3', 'https://www.youtube.com/embed/' + self.video_id)
+        video = self.portal['video3']
+        view = video.restrictedTraverse('@@wildcard_video_view')
+        embed_url = 'https://www.youtube.com/embed/' + self.video_id
+        self.assertEqual(view.get_embed_url(), embed_url)
+
+
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
Hi, this pr is related to the issue #29.
Now the youtube_url input can take some different types of url and in the view will be used the iframe to embed the video.

I've made some basic tests. Let me know if you want more complex tests.

There is an [old test] (https://github.com/collective/wildcard.media/blob/ab3746769197995fafff80629863bda9fcd50348/wildcard/media/tests/test_video.py#L161) that fails..maybe something is changed and now there is only 1 <source> tag in the html?