### PR TITLE
Manage splash screen from youtube

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,9 +4,11 @@ Changelog
 2.0.3 (Unreleased)
 ------------------
 
-- For youtube videos, use the iframe instead simple html5 video tag.
+- For youtube videos, use the iframe instead simple html5 video tag
   [cekk]
 
+- Automatically get thumbnail image for youtube videos on creation/edit
+  [cekk]
 
 2.0.2 (2015-11-25)
 ------------------

--- a/wildcard/media/__init__.py
+++ b/wildcard/media/__init__.py
@@ -1,3 +1,4 @@
+from logging import getLogger
 from zope.i18nmessageid import MessageFactory
 import permissions  # noqa
 permissions  # pyflakes
@@ -7,3 +8,5 @@ _ = MessageFactory('wildcard.media')
 
 def initialize(context):
     """Initializer called when used as a Zope 2 product."""
+
+logger = getLogger('wildcard.media')

--- a/wildcard/media/behavior.py
+++ b/wildcard/media/behavior.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import re
 
 from plone.app.textfield import RichText
 from plone.autoform import directives as form
@@ -235,6 +236,16 @@ class Video(BaseAdapter):
         elif value != getattr(self.context, 'video_file', _marker):
             self.context.video_converted = False
             self.context.video_file = value
+
+    def get_youtube_id_from_url(self):
+        if not getattr(self.context, 'youtube_url', None):
+            return ""
+        pattern = r"((?<=(v|V)/)|(?<=be/)|(?<=(\?|\&)v=)|(?<=embed/))([\w-]+)"
+        match = re.search(pattern, self.context.youtube_url)
+        if not match:
+            return ""
+        return match.group()
+
     video_file = property(_get_video_file, _set_video_file)
 
     image = BasicProperty(IVideo['image'])

--- a/wildcard/media/behavior.py
+++ b/wildcard/media/behavior.py
@@ -10,13 +10,13 @@ from plone.namedfile import field as namedfile
 from plone.supermodel import model
 from wildcard.media import _
 from wildcard.media.browser.widget import StreamNamedFileFieldWidget
+from wildcard.media.settings import GlobalSettings
 from z3c.form.interfaces import IAddForm, IEditForm
 from zope import schema
 from zope.component import adapts
-from zope.interface import Invalid, invariant
-from zope.interface import alsoProvides, implements
 from zope.component.hooks import getSite
-from wildcard.media.settings import GlobalSettings
+from zope.interface import alsoProvides, implements
+from zope.interface import Invalid, invariant
 
 try:
     from wildcard.media import youtube
@@ -98,6 +98,12 @@ class IVideo(model.Schema):
                       u"with video url."),
         required=False
     )
+    retrieve_thumb = schema.Bool(
+        title=_(u'Retrieve original thumbnail from youtube'),
+        description=_(u"If checked, try to download original thumbnail from "
+                      u"youtube into this video."),
+        required=False,
+        default=False)
 
     @invariant
     def validate_videos(data):
@@ -250,6 +256,7 @@ class Video(BaseAdapter):
 
     image = BasicProperty(IVideo['image'])
     youtube_url = BasicProperty(IVideo['youtube_url'])
+    retrieve_thumb = BasicProperty(IVideo['retrieve_thumb'])
     width = BasicProperty(IVideo['width'])
     height = BasicProperty(IVideo['height'])
     transcript = BasicProperty(IVideo['transcript'])

--- a/wildcard/media/browser/templates/video_macro.pt
+++ b/wildcard/media/browser/templates/video_macro.pt
@@ -1,4 +1,4 @@
-<div metal:define-macro="video">
+<div metal:define-macro="video" i18n:domain="wildcard.media">
 
 <div class="wcvideo-container"
      tal:define="util video/@@wcmedia-utils|context/@@wcmedia-utils;
@@ -43,11 +43,13 @@
   <tal:no_image condition="not:util/image_url">
     <p class="discreet" tal:define="edit_url view/get_edit_url"
        tal:condition="edit_url">
-      The video doesn't have a saved thumbnail image. Try to
-      <a tal:attributes="href edit_url" title="edit video"> edit </a>
-      it and enable "Retrieve original thumbnail" field.
-      <br /> If you uploaded a video to YouTube, it is possible that the thumbnail wasn't available
-      at upload time. Try to re-save the video to reload the image.
+      <tal:no_image i18n:translate="">This video doesn't have a saved thumbnail image. </tal:no_image>
+      <br /><a tal:attributes="href edit_url" title="edit video" i18n:translate="">Edit </a>
+      <tal:no_image i18n:translate="">
+        it and enable "Retrieve original thumbnail" field.
+        <br /> If you uploaded a video to YouTube, it is possible that the thumbnail wasn't available
+        at upload time. Try to re-save the video to reload the image.
+      </tal:no_image>
     </p>
   </tal:no_image>
   <iframe

--- a/wildcard/media/browser/templates/video_macro.pt
+++ b/wildcard/media/browser/templates/video_macro.pt
@@ -40,6 +40,16 @@
     </video>
 </tal:has_video>
 <tal:yt tal:condition="youtube_url">
+  <tal:no_image condition="not:util/image_url">
+    <p class="discreet" tal:define="edit_url view/get_edit_url"
+       tal:condition="edit_url">
+      The video doesn't have a saved thumbnail image. Try to
+      <a tal:attributes="href edit_url" title="edit video"> edit </a>
+      it and enable "Retrieve original thumbnail" field.
+      <br /> If you uploaded a video to YouTube, it is possible that the thumbnail wasn't available
+      at upload time. Try to re-save the video to reload the image.
+    </p>
+  </tal:no_image>
   <iframe
     tal:attributes="width width;
                     height height;
@@ -47,12 +57,6 @@
     frameborder="0"
     allowfullscreen>
   </iframe>
-    <!-- <video width="640" height="360" id="player1" preload="none" class="active pat-media"
-           tal:attributes="width width;
-                           height height;">
-        <source type="video/youtube" src="http://www.youtube.com/watch?v=nOEw9iiopwI"
-                tal:attributes="src video/youtube_url" />
-    </video> -->
 </tal:yt>
 </div>
 

--- a/wildcard/media/browser/views.py
+++ b/wildcard/media/browser/views.py
@@ -4,6 +4,7 @@ import re
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as pmf
 from Products.Five import BrowserView
+from plone import api
 from plone.app.z3cform.layout import wrap_form
 from plone.memoize.instance import memoize
 from wildcard.media import _
@@ -69,6 +70,18 @@ class VideoView(BrowserView):
         if not video_id:
             return ""
         return "https://www.youtube.com/embed/" + video_id
+
+    def get_edit_url(self):
+        """
+        If the user can edit the video, returns the edit url.
+        """
+        if not api.user.has_permission(
+            'Modify portal content',
+            obj=self.context):
+            return ""
+        from plone.protect.utils import addTokenToUrl
+        url = "%s/@@edit" % self.context.absolute_url()
+        return addTokenToUrl(url)
 
 
 class GlobalSettingsForm(form.EditForm):

--- a/wildcard/media/browser/views.py
+++ b/wildcard/media/browser/views.py
@@ -7,6 +7,7 @@ from Products.Five import BrowserView
 from plone.app.z3cform.layout import wrap_form
 from plone.memoize.instance import memoize
 from wildcard.media import _
+from wildcard.media.behavior import IVideo
 from wildcard.media.config import getFormat
 from wildcard.media.interfaces import IGlobalMediaSettings
 from wildcard.media.interfaces import IMediaEnabled
@@ -17,7 +18,6 @@ from z3c.form import field
 from z3c.form import form
 from zope.component.hooks import getSite
 from zope.interface import alsoProvides
-
 
 try:
     from wildcard.media import youtube
@@ -62,13 +62,12 @@ class VideoView(BrowserView):
         - 'https://www.youtube.com/watch?v=VIDEO_ID'
         - 'https://www.youtube.com/embed/2Lb2BiUC898'
         """
-        if not getattr(self.context, 'youtube_url', None):
+        video_behavior = IVideo(self.context)
+        if not video_behavior:
             return ""
-        pattern = r"((?<=(v|V)/)|(?<=be/)|(?<=(\?|\&)v=)|(?<=embed/))([\w-]+)"
-        match = re.search(pattern, self.context.youtube_url)
-        if not match:
+        video_id = video_behavior.get_youtube_id_from_url()
+        if not video_id:
             return ""
-        video_id = match.group()
         return "https://www.youtube.com/embed/" + video_id
 
 

--- a/wildcard/media/locales/it/LC_MESSAGES/wildcard.media.po
+++ b/wildcard/media/locales/it/LC_MESSAGES/wildcard.media.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-10 15:49+0000\n"
+"POT-Creation-Date: 2016-02-10 16:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Luca Fabbri <keul@redturtle.it>\n"
 "Language-Team: RedTurtle Technology <sviluppoplone@redturtle.it>\n"
@@ -50,6 +50,10 @@ msgstr "Altezza di default del video"
 msgid "Default video width"
 msgstr "Larghezza di default del video"
 
+#: ../browser/templates/video_macro.pt:47
+msgid "Edit"
+msgstr "Modificalo"
+
 #: ../behavior.py:119
 msgid "Height"
 msgstr "Altezza"
@@ -84,6 +88,10 @@ msgstr "Scarica la miniatura originale da youtube"
 #: ../behavior.py:124
 msgid "Subtitle file"
 msgstr "File sottotitoli"
+
+#: ../browser/templates/video_macro.pt:46
+msgid "This video doesn't have a saved thumbnail image."
+msgstr "Questo video non ha una miniatura salvata."
 
 #: ../behavior.py:135
 msgid "Transcript"
@@ -126,6 +134,10 @@ msgstr "Passa un parametro opzionale per outfile ad aconv durante il processo di
 #: ../browser/views.py:91
 msgid "description_media_global_settings_form"
 msgstr "Configura i parametri per il multimedia."
+
+#: ../browser/templates/video_macro.pt:48
+msgid "it and enable \"Retrieve original thumbnail\" field. <br /> If you uploaded a video to YouTube, it is possible that the thumbnail wasn't available at upload time. Try to re-save the video to reload the image."
+msgstr "e abilita il campo \"Retrieve original thumbnail\". <br /> Se hai fatto un upload su YouTube, è possibile che l'immagine non sia ancora disponibile. Riprova a salvare il video più tardi."
 
 #. Default: "Media View"
 #: ../tiles/mediaview.py:41

--- a/wildcard/media/locales/it/LC_MESSAGES/wildcard.media.po
+++ b/wildcard/media/locales/it/LC_MESSAGES/wildcard.media.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-12 08:29+0000\n"
+"POT-Creation-Date: 2016-02-10 15:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Luca Fabbri <keul@redturtle.it>\n"
 "Language-Team: RedTurtle Technology <sviluppoplone@redturtle.it>\n"
@@ -18,7 +18,7 @@ msgstr ""
 msgid "Additional Video Formats"
 msgstr "Formati Video Aggiuntivi"
 
-#: ../behavior.py:94
+#: ../behavior.py:95
 msgid "Alternatively, you can provide a youtube video url. If this is specified, video file will be ignored. If video was uploaded to youtube, this field will be filled with video url."
 msgstr "In alternativa, puoi fornire l'url di un video su YouTube. Se lo inserisci, il file video verrà ignorato. Se il file video è stato caricato su YouTube, questo campo verrà popolato con il suo url."
 
@@ -26,7 +26,7 @@ msgstr "In alternativa, puoi fornire l'url di un video su YouTube. Se lo inseris
 msgid "Async Quota Size"
 msgstr "Dimensione Quota Async"
 
-#: ../behavior.py:146
+#: ../behavior.py:153
 msgid "Audio File"
 msgstr "File Audio"
 
@@ -38,7 +38,7 @@ msgstr "Opzioni di Infile per la conversione"
 msgid "Convert Outfile Options"
 msgstr "Opzioni di Outfile per la conversione"
 
-#: ../behavior.py:54
+#: ../behavior.py:55
 msgid "Cover Image"
 msgstr "Immagine Copertina"
 
@@ -50,11 +50,15 @@ msgstr "Altezza di default del video"
 msgid "Default video width"
 msgstr "Larghezza di default del video"
 
-#: ../behavior.py:112
+#: ../behavior.py:119
 msgid "Height"
 msgstr "Altezza"
 
-#: ../browser/views.py:56
+#: ../behavior.py:103
+msgid "If checked, try to download original thumbnail from youtube into this video."
+msgstr "Se selezionato, prova a scaricare la miniatura originale da youtube e salvarla nel video."
+
+#: ../browser/views.py:90
 #: ../profiles/default/controlpanel.xml
 msgid "Media Settings"
 msgstr "Impostazioni Multimedia"
@@ -65,35 +69,39 @@ msgstr ""
 "Numero di conversioni da lanciare in una volta.\n"
 "Il nome della quota assegnata è  `wildcard.media`."
 
-#: ../behavior.py:118
+#: ../behavior.py:125
 msgid "Provide a file in srt format"
 msgstr "Fornisci un file in formato srt"
 
-#: ../behavior.py:72
+#: ../behavior.py:73
 msgid "Requires having youtube account connected. Videos that are private will remain unlisted on YouTube. Once published, video will be made public on YouTube. "
 msgstr "E' necessatio avere un account YouTube collegato. I video privati non saranno visibili su YouTube. Una volta pubblicati, verranno anche resi visibili su YouTube."
 
-#: ../behavior.py:117
+#: ../behavior.py:102
+msgid "Retrieve original thumbnail from youtube"
+msgstr "Scarica la miniatura originale da youtube"
+
+#: ../behavior.py:124
 msgid "Subtitle file"
 msgstr "File sottotitoli"
 
-#: ../behavior.py:128
+#: ../behavior.py:135
 msgid "Transcript"
 msgstr "Trascrizione"
 
-#: ../behavior.py:71
+#: ../behavior.py:72
 msgid "Upload to youtube"
 msgstr "Carica su YouTube"
 
-#: ../behavior.py:63
+#: ../behavior.py:64
 msgid "Video File"
 msgstr "File Video"
 
-#: ../behavior.py:107
+#: ../behavior.py:114
 msgid "Width"
 msgstr "Larghezza"
 
-#: ../behavior.py:93
+#: ../behavior.py:94
 msgid "Youtube URL"
 msgstr "URL YouTube"
 
@@ -115,7 +123,7 @@ msgid "convert_outfile_options_help"
 msgstr "Passa un parametro opzionale per outfile ad aconv durante il processo di conversione."
 
 #. Default: "Configure the parameters for media."
-#: ../browser/views.py:57
+#: ../browser/views.py:91
 msgid "description_media_global_settings_form"
 msgstr "Configura i parametri per il multimedia."
 
@@ -123,3 +131,18 @@ msgstr "Configura i parametri per il multimedia."
 #: ../tiles/mediaview.py:41
 msgid "msg_short_name_mediaview"
 msgstr "Vista Multimedia"
+
+#. Default: "Unable to download thumbnail image automatically from youtube. Try later."
+#: ../subscribers.py:73
+msgid "yt_image_download_error_label"
+msgstr "Impossibile scaricare la miniatura in automatico da youtube. Riprova più tardi."
+
+#. Default: "Unable to download thumbnail image automatically from youtube. Probably it isn't available yet. Please retry in a few minutes."
+#: ../subscribers.py:99
+msgid "yt_image_download_notfound_error_label"
+msgstr "Impossibile scaricare la miniatura in automatico da youtube. Probabilmente non è ancora disponibile. Riprova più tardi."
+
+#. Default: "Thumbnail image correctly saved from youtube."
+#: ../subscribers.py:116
+msgid "yt_image_download_success_label"
+msgstr "Miniatura scaricata correttamente da youtube."

--- a/wildcard/media/locales/wildcard.media.pot
+++ b/wildcard/media/locales/wildcard.media.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-10 15:49+0000\n"
+"POT-Creation-Date: 2016-02-10 16:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,6 +53,10 @@ msgstr ""
 msgid "Default video width"
 msgstr ""
 
+#: ../browser/templates/video_macro.pt:47
+msgid "Edit"
+msgstr ""
+
 #: ../behavior.py:119
 msgid "Height"
 msgstr ""
@@ -84,6 +88,10 @@ msgstr ""
 
 #: ../behavior.py:124
 msgid "Subtitle file"
+msgstr ""
+
+#: ../browser/templates/video_macro.pt:46
+msgid "This video doesn't have a saved thumbnail image."
 msgstr ""
 
 #: ../behavior.py:135
@@ -124,6 +132,10 @@ msgstr ""
 #. Default: "Configure the parameters for media."
 #: ../browser/views.py:91
 msgid "description_media_global_settings_form"
+msgstr ""
+
+#: ../browser/templates/video_macro.pt:48
+msgid "it and enable \"Retrieve original thumbnail\" field. <br /> If you uploaded a video to YouTube, it is possible that the thumbnail wasn't available at upload time. Try to re-save the video to reload the image."
 msgstr ""
 
 #. Default: "Media View"

--- a/wildcard/media/locales/wildcard.media.pot
+++ b/wildcard/media/locales/wildcard.media.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-12 08:29+0000\n"
+"POT-Creation-Date: 2016-02-10 15:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "Additional Video Formats"
 msgstr ""
 
-#: ../behavior.py:94
+#: ../behavior.py:95
 msgid "Alternatively, you can provide a youtube video url. If this is specified, video file will be ignored. If video was uploaded to youtube, this field will be filled with video url."
 msgstr ""
 
@@ -29,7 +29,7 @@ msgstr ""
 msgid "Async Quota Size"
 msgstr ""
 
-#: ../behavior.py:146
+#: ../behavior.py:153
 msgid "Audio File"
 msgstr ""
 
@@ -41,7 +41,7 @@ msgstr ""
 msgid "Convert Outfile Options"
 msgstr ""
 
-#: ../behavior.py:54
+#: ../behavior.py:55
 msgid "Cover Image"
 msgstr ""
 
@@ -53,11 +53,15 @@ msgstr ""
 msgid "Default video width"
 msgstr ""
 
-#: ../behavior.py:112
+#: ../behavior.py:119
 msgid "Height"
 msgstr ""
 
-#: ../browser/views.py:56
+#: ../behavior.py:103
+msgid "If checked, try to download original thumbnail from youtube into this video."
+msgstr ""
+
+#: ../browser/views.py:90
 #: ../profiles/default/controlpanel.xml
 msgid "Media Settings"
 msgstr ""
@@ -66,35 +70,39 @@ msgstr ""
 msgid "Number of conversions to run at a time. The quota name assigned is `wildcard.media`."
 msgstr ""
 
-#: ../behavior.py:118
+#: ../behavior.py:125
 msgid "Provide a file in srt format"
 msgstr ""
 
-#: ../behavior.py:72
+#: ../behavior.py:73
 msgid "Requires having youtube account connected. Videos that are private will remain unlisted on YouTube. Once published, video will be made public on YouTube. "
 msgstr ""
 
-#: ../behavior.py:117
+#: ../behavior.py:102
+msgid "Retrieve original thumbnail from youtube"
+msgstr ""
+
+#: ../behavior.py:124
 msgid "Subtitle file"
 msgstr ""
 
-#: ../behavior.py:128
+#: ../behavior.py:135
 msgid "Transcript"
 msgstr ""
 
-#: ../behavior.py:71
+#: ../behavior.py:72
 msgid "Upload to youtube"
 msgstr ""
 
-#: ../behavior.py:63
+#: ../behavior.py:64
 msgid "Video File"
 msgstr ""
 
-#: ../behavior.py:107
+#: ../behavior.py:114
 msgid "Width"
 msgstr ""
 
-#: ../behavior.py:93
+#: ../behavior.py:94
 msgid "Youtube URL"
 msgstr ""
 
@@ -114,12 +122,27 @@ msgid "convert_outfile_options_help"
 msgstr ""
 
 #. Default: "Configure the parameters for media."
-#: ../browser/views.py:57
+#: ../browser/views.py:91
 msgid "description_media_global_settings_form"
 msgstr ""
 
 #. Default: "Media View"
 #: ../tiles/mediaview.py:41
 msgid "msg_short_name_mediaview"
+msgstr ""
+
+#. Default: "Unable to download thumbnail image automatically from youtube. Try later."
+#: ../subscribers.py:73
+msgid "yt_image_download_error_label"
+msgstr ""
+
+#. Default: "Unable to download thumbnail image automatically from youtube. Probably it isn't available yet. Please retry in a few minutes."
+#: ../subscribers.py:99
+msgid "yt_image_download_notfound_error_label"
+msgstr ""
+
+#. Default: "Thumbnail image correctly saved from youtube."
+#: ../subscribers.py:116
+msgid "yt_image_download_success_label"
 msgstr ""
 

--- a/wildcard/media/subscribers.py
+++ b/wildcard/media/subscribers.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from plone import api
 from plone.namedfile.file import NamedBlobImage
 from wildcard.media.async import (
     convertVideoFormats,
@@ -6,8 +7,11 @@ from wildcard.media.async import (
     removeFromYouTube,
     updateYouTubePermissions,
     editYouTubeVideo)
+from wildcard.media import _
 from wildcard.media.behavior import IVideo
-from wildcard.media.youtube import downloadThumbFromYouTube
+from requests.exceptions import Timeout
+from wildcard.media import logger
+import requests
 
 
 def video_added(video, event):
@@ -16,12 +20,13 @@ def video_added(video, event):
             uploadToYouTube(video)
         else:
             convertVideoFormats(video)
-    elif getattr(video, 'youtube_url', None):
+    if getattr(video, 'youtube_url', None) and getattr(video, 'retrieve_thumb', False):
+        # it has youtube_url set if is a remote video or is uploaded to youtube
         retrieveThumbImage(video)
 
 
 def video_edited(video, event):
-    if getattr(video, 'youtube_url', None):
+    if getattr(video, 'youtube_url', None) and getattr(video, 'retrieve_thumb', False):
         retrieveThumbImage(video)
     elif getattr(video, 'youtube_data', False):
         if not getattr(video, 'upload_video_to_youtube', False):
@@ -64,7 +69,51 @@ def retrieveThumbImage(video):
     video_id = video_behavior.get_youtube_id_from_url()
     if not video_id:
         return
-    image = downloadThumbFromYouTube(video_id)
-    if not image:
+    url = "https://i.ytimg.com/vi/%s/hqdefault.jpg" % video_id
+    error_msg = _(
+        'yt_image_download_error_label',
+        'Unable to download thumbnail image automatically from youtube. Try later.'
+    )
+    try:
+        res = requests.get(url, stream=True, timeout=10)
+    except Timeout:
+        logger.error(
+            'Unable to retrieve thumbnail image for "%s": timeout.' % video_id)
+        api.portal.show_message(
+            message=error_msg,
+            request=video.REQUEST,
+            type="warning")
         return
-    video.image = NamedBlobImage(image, filename=u'%s.jpg' % video_id)
+    except Exception as e:
+        logger.error('Unable to retrieve thumbnail from "%s".' % url)
+        logger.exception(e)
+        api.portal.show_message(
+            message=error_msg,
+            request=video.REQUEST,
+            type="warning")
+        return
+    if not res.ok:
+        if res.status_code == 404:
+            logger.error(
+                'Unable to retrieve thumbnail from "%s". Not found.' % url)
+            error_msg = _(
+                'yt_image_download_notfound_error_label',
+                "Unable to download thumbnail image automatically from youtube. Probably it isn't available yet. Please retry in a few minutes."
+            )
+            api.portal.show_message(
+                message=error_msg,
+                request=video.REQUEST,
+                type="warning")
+        else:
+            logger.error('Unable to retrieve thumbnail from "%s". Error: %s' % (url, res.status_code))
+            api.portal.show_message(
+                message=error_msg,
+                request=video.REQUEST,
+                type="warning")
+        return
+    video.image = NamedBlobImage(res.raw.data, filename=u'%s.jpg' % video_id)
+    api.portal.show_message(
+        message=_(
+            'yt_image_download_success_label',
+            'Thumbnail image correctly saved from youtube.'),
+        request=video.REQUEST)

--- a/wildcard/media/subscribers.py
+++ b/wildcard/media/subscribers.py
@@ -1,21 +1,33 @@
+import requests
+
+from plone.namedfile.file import NamedBlobImage
+from requests.exceptions import Timeout
+
+from wildcard.media import logger
 from wildcard.media.async import (
     convertVideoFormats,
     uploadToYouTube,
     removeFromYouTube,
     updateYouTubePermissions,
     editYouTubeVideo)
+from wildcard.media.behavior import IVideo
 
 
 def video_added(video, event):
     if getattr(video, 'video_file', None):
         if getattr(video, 'upload_video_to_youtube', False):
             uploadToYouTube(video)
+            retrieveThumbFromYoutube(video)
         else:
             convertVideoFormats(video)
+    if getattr(video, 'youtube_url', None):
+        retrieveThumbFromYoutube(video)
 
 
 def video_edited(video, event):
-    if getattr(video, 'youtube_data', False):
+    if getattr(video, 'youtube_url', None):
+        retrieveThumbFromYoutube(video)
+    elif getattr(video, 'youtube_data', False):
         if not getattr(video, 'upload_video_to_youtube', False):
             # previously set to put on youtube, but no longer set to be on youtube
             removeFromYouTube(video)
@@ -43,3 +55,33 @@ def video_state_changed(video, event):
             getattr(video, 'youtube_data', None)):
         # check permission
         updateYouTubePermissions(video)
+
+
+def retrieveThumbFromYoutube(video):
+    """
+    Try to call Youtube service to retrieve video thumbnail
+    and save it in the video
+    """
+    video_behavior = IVideo(video)
+    if not video_behavior:
+        return
+    video_id = video_behavior.get_youtube_id_from_url()
+    if not video_id:
+        return
+    url = "http://img.youtube.com/vi/%s/0.jpg" % video_id
+    try:
+        res = requests.get(url, stream=True, timeout=10)
+    except Timeout:
+        logger.error('Unable to retrieve thumbnail image for "%s": timeout.' % video_id)
+        return
+    except Exception as e:
+        logger.error('Unable to retrieve thumbnail from "%s".' % url)
+        logger.exception(e)
+        return
+    if not res.ok:
+        if res.status_code == 404:
+            logger.error('Unable to retrieve thumbnail from "%s". Not found.' % url)
+        else:
+            logger.error('Unable to retrieve thumbnail from "%s". Error: %s' % (url, res.status_code))
+        return None
+    video.image = NamedBlobImage(res.raw.data, filename=u'%s.jpg' % video_id)

--- a/wildcard/media/tests/test_video.py
+++ b/wildcard/media/tests/test_video.py
@@ -191,9 +191,10 @@ class YoutubeVideoIntegrationTest(unittest.TestCase):
     def getFti(self):
         return queryUtility(IDexterityFTI, name='WildcardVideo')
 
-    def create(self, id, video_url):
+    def create(self, id, video_url, retrieve_thumb=False):
         self.portal.invokeFactory('WildcardVideo', id,
-                                  youtube_url=video_url)
+                                  youtube_url=video_url,
+                                  retrieve_thumb=retrieve_thumb)
         return self.portal[id]
 
     def test_extract_yt_video_id(self):
@@ -221,13 +222,21 @@ class YoutubeVideoIntegrationTest(unittest.TestCase):
 
     def test_yt_video_thumb(self):
         image1 = getattr(self.video1, 'image', None)
-        self.assertNotEqual(image1, None)
-        self.assertEqual(image1.getImageSize(), (480, 360))
-        self.assertEqual(image1.filename, "%s.jpg" % self.video_id)
+        self.assertEqual(image1, None)
 
-        self.create('video4', 'https://youtu.be/foo')
-        image4 = getattr(self.portal['video4'], 'image', None)
-        self.assertEqual(image4, None)
+        self.create(
+            id='video4',
+            video_url='https://www.youtube.com/embed/' + self.video_id,
+            retrieve_thumb=True)
+        video4 = self.portal['video4']
+        image4 = getattr(video4, 'image', None)
+        self.assertNotEqual(image4, None)
+        self.assertEqual(image4.getImageSize(), (480, 360))
+        self.assertEqual(image4.filename, "%s.jpg" % self.video_id)
+
+        self.create('video5', 'https://youtu.be/foo')
+        image5 = getattr(self.portal['video5'], 'image', None)
+        self.assertEqual(image5, None)
 
 
 def test_suite():

--- a/wildcard/media/youtube.py
+++ b/wildcard/media/youtube.py
@@ -1,9 +1,6 @@
 from oauthlib.oauth2 import WebApplicationClient
 from plone import api
-from plone.namedfile.file import NamedBlobImage
 from plone.registry.interfaces import IRegistry
-from requests.exceptions import Timeout
-from wildcard.media import logger
 from zope.component import getUtility
 from zope.globalrequest import getRequest
 
@@ -198,13 +195,6 @@ def uploadToYouTube(video):
     video_id = video.youtube_data['id']
     video.youtube_url = u'https://www.youtube.com/watch?v=%s' % video_id
     video.video_converted = True
-    # get thumbnail from youtube. In youtube_data there are the urls for thumbs
-    # but i prefer to pass the id to a common method.
-    logger.info(video.youtube_data['snippet']['thumbnails'])
-    image = downloadThumbFromYouTube(video_id)
-    if not image:
-        return
-    video.image = NamedBlobImage(image, filename=u'%s.jpg' % video_id)
 
 
 def removeFromYouTube(video):
@@ -246,25 +236,3 @@ def editYouTubeVideo(video):
     if not api.authorized:
         raise Exception("Website is not authorized to upload to YouTube")
     api.edit_video(video.youtube_data, video.Title(), video.Description())
-
-
-def downloadThumbFromYouTube(video_id):
-    if not video_id:
-        return None
-    url = "https://i.ytimg.com/vi/%s/hqdefault.jpg" % video_id
-    try:
-        res = requests.get(url, stream=True, timeout=10)
-    except Timeout:
-        logger.error('Unable to retrieve thumbnail image for "%s": timeout.' % video_id)
-        return
-    except Exception as e:
-        logger.error('Unable to retrieve thumbnail from "%s".' % url)
-        logger.exception(e)
-        return
-    if not res.ok:
-        if res.status_code == 404:
-            logger.error('Unable to retrieve thumbnail from "%s". Not found.' % url)
-        else:
-            logger.error('Unable to retrieve thumbnail from "%s". Error: %s' % (url, res.status_code))
-        return None
-    return res.raw.data


### PR DESCRIPTION
Hi, with this PR i would like to improve the discussion of #11 

I added a new field in video behavior to enable/disable automatic thumb download from youtube.
If set, on creation and on every edit there is an event handler that try to download the thumb from youtube.

I have only some doubts:
- image field should still be hidden and "Unsettable"?
- if you upload a video to youtube with the api, Youtube takes several seconds (or minutes..depends to the video size) to provide the thumb image, and the event can't get it. For now i've put a message and a link to the edit form to force the user to re-save the video. This isn't the best approach (i know), but is the fastest and i don't know how do you prefer handle this case. Let me know what do you think and i'll improve it :)
- there is still a test that fails: **test_view**, that expects 3 scripts, but now there are only one in the video view.