### PR TITLE
make thumbnail creation work on Windows

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+(unreleased)
+------------
+
+- make thumbnail creation work on Windows
+  [tschorr]
+
 2.0.3 (2016-03-01)
 ------------------
 

--- a/wildcard/media/convert.py
+++ b/wildcard/media/convert.py
@@ -214,8 +214,9 @@ def _convertFormat(context):
     try:
         avconv.grab_frame(tmpfilepath, output_filepath)
         if os.path.exists(output_filepath):
-            fi = open(output_filepath)
-            context.image = NamedBlobImage(fi, filename=u'screengrab.png')
+            with open(output_filepath, 'rb') as fi:
+                data = fi.read()
+            context.image = NamedBlobImage(data, filename=u'screengrab.png')
             fi.close()
     except:
         logger.warn('error getting thumbnail from video')


### PR DESCRIPTION
Thumbnail creation on Windows currently fails because opening the file before passing it to NamedBlobFile results in Windows Error 32 ("The process cannot access the file because it is being used by another process.").
Passing only the file data as a string fixes this.