### PR TITLE
Add TinyMCE menu item to add wcvideo span

### DIFF
--- a/wildcard/media/profiles/plone5/registry.xml
+++ b/wildcard/media/profiles/plone5/registry.xml
@@ -11,4 +11,21 @@
     <value key="depends">plone</value>
   </records>
 
+   <records interface="Products.CMFPlone.interfaces.ITinyMCESchema" prefix="plone">
+        <value key="other_settings">
+            {
+            "style_formats": [
+            {
+            "title": "Embedded video",
+            "inline": "span",
+            "attributes": {
+            "class": "wcvideo"
+            }
+            }
+            ],
+            "style_formats_merge": "True"
+            }
+        </value>
+    </records>
+
 </registry>


### PR DESCRIPTION
This PR add one menu item in TinyMCE editor to add wcvideo span around video link.