### PR TITLE
WIP: fixed hardcoded enclosure on AudioFeedItem

### DIFF
--- a/wildcard/media/browser/syndication.py
+++ b/wildcard/media/browser/syndication.py
@@ -10,7 +10,9 @@ class AudioFeedItem(DexterityItem):
 
     @property
     def has_enclosure(self):
-        return True
+        if self.context.audio_file:
+            return True
+        return False
 
     @property
     def file_url(self):


### PR DESCRIPTION
`has_enclosure` is hardcoded for AudioFeedItem but not for VideoFeedItem.
see: 
https://github.com/collective/wildcard.media/blob/master/wildcard/media/browser/syndication.py#L11-L13

This breaks social tags on plone.app.layout 2.5.x on In Plone 5.0.x.
Resulting in an 
"error while rendering plone.htmlhead.socialtags" on Plone 5.0.x

This pull request fixes the issue by providing a proper `has_enclosure` for AudioFeedItem

I've marked it WIP as I need to add some tests etc...
