### PR TITLE
Use prefered python version check in code

### DIFF
--- a/wildcard/media/convert.py
+++ b/wildcard/media/convert.py
@@ -126,7 +126,7 @@ class AVProbeProcess(BaseSubProcess):
         cmd = [self.binary, filepath]
         result = {}
         for line in self._run_command(cmd, or_error=True).splitlines():
-            if six.PY3:
+            if not six.PY2:
                 line = line.decode()
             if ':' not in line:
                 continue


### PR DESCRIPTION
`if not six.PY2` vs. `if six.PY3`